### PR TITLE
Refactor item and boost handling by integrating Items class in MainGame

### DIFF
--- a/src/maingame.py
+++ b/src/maingame.py
@@ -6,6 +6,7 @@ import pygame
 from button import Button
 from player import Player
 from terrain import Terrain
+from items import Items
 
 os.environ['SDL_VIDEO_CENTERED'] = '1'  # toto nam umozni menit rozliseni bez pohybu okna
 
@@ -56,13 +57,13 @@ class MainGame:
         paused = False
         player = Player()
         terrain = Terrain(self.WIDTH, self.HEIGHT)
+        items = Items()
         terrain_data = terrain.get_map(difficulty)
         score = 0
 
         ground_rects = terrain_data["ground_rects"]
         platform_rects = terrain_data["platform_rects"]
-        item_rects = terrain_data["items"]
-        boost_rects = terrain_data["boosts"]
+        item_rects, boost_rects = items.get_items_and_boosts(difficulty)
 
         background = pygame.image.load("assets/sprites/game_sprites/background.png").convert()
         background_width = background.get_width()
@@ -113,11 +114,11 @@ class MainGame:
                 pygame.time.wait(500)
                 player = Player()
                 terrain = Terrain(self.WIDTH, self.HEIGHT)
+                items = Items()
                 terrain_data = terrain.get_map(difficulty)
                 ground_rects = terrain_data["ground_rects"]
                 platform_rects = terrain_data["platform_rects"]
-                item_rects = terrain_data["items"]
-                boost_rects = terrain_data["boosts"]
+                item_rects, boost_rects = items.get_items_and_boosts(difficulty)
                 score = 0
 
             scroll_x = max(0, min(player.x - self.WIDTH // 2, background_width - self.WIDTH))

--- a/src/terrain.py
+++ b/src/terrain.py
@@ -29,27 +29,6 @@ class Terrain:
                     pygame.Rect(1450, platform_y[9], 100, platform_height),
                     pygame.Rect(1600, platform_y[10], 200, platform_height),
                 ],
-                "items": [
-                    pygame.Rect(182, int(screen_height * 0.60), 16, 16),
-                    pygame.Rect(332, int(screen_height * 0.50), 16, 16),
-                    pygame.Rect(482, int(screen_height * 0.40), 16, 16),
-                    pygame.Rect(632, int(screen_height * 0.30), 16, 16),
-                    pygame.Rect(232, int(screen_height * 0.19), 16, 16),
-                    pygame.Rect(832, int(screen_height * 0.19), 16, 16),
-                    pygame.Rect(1482, int(screen_height * 0.40), 16, 16),
-                    pygame.Rect(600, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(700, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(800, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(1200, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(1300, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(1400, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(1900, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(2000, int(screen_height * 0.70), 16, 16),
-                    pygame.Rect(2100, int(screen_height * 0.70), 16, 16),
-                ],
-                "boosts": [
-                    pygame.Rect(1332, int(screen_height * 0.30), 16, 16),
-                ],
             },
         }
 


### PR DESCRIPTION
This pull request refactors item and boost handling in the game by introducing a new `Items` class to encapsulate their logic. The changes improve code organization and maintainability by moving item and boost data out of the `Terrain` class and into the new `Items` class.

### Refactoring for item and boost handling:
* Added import for the new `Items` class in `src/maingame.py` and instantiated it in the `play` method to manage item and boost data. (`[[1]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R9)`, `[[2]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R60-R66)`, `[[3]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R117-R121)`)
* Replaced direct access to `items` and `boosts` in the `Terrain` data with a call to `items.get_items_and_boosts(difficulty)` in the `play` method. (`[[1]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R60-R66)`, `[[2]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R117-R121)`)

### Code cleanup in `Terrain`:
* Removed hardcoded `items` and `boosts` data from the `Terrain` class, as this responsibility has been moved to the `Items` class. (`[src/terrain.pyL32-L52](diffhunk://#diff-fd86f3d8b7d2a19acc00ef758873e04d1f5d42da59716823e49b6dd179de7a6eL32-L52)`)