### PR TITLE
Enhance item handling by storing positions as proportions

### DIFF
--- a/src/character.py
+++ b/src/character.py
@@ -65,7 +65,8 @@ class Character:
         player_rect = self.get_rect()
         prev_bottom = player_rect.bottom - self.velocity_y
 
-        # Kolize na osu Y
+        # Kolize na osu Y (vylepšená detekce "on_ground" na hraně)
+        ground_check_rect = player_rect.inflate(8, 0)  # rozšíříme kolizní obdélník o 8px do stran
         for rect in terrain:
             if player_rect.colliderect(rect):
                 if prev_bottom <= rect.top + 10:

--- a/src/items.py
+++ b/src/items.py
@@ -2,32 +2,35 @@ import pygame
 
 class Items:
     def __init__(self):
+        # Store item positions as (x, y) proportions of width/height
         self.item_data = {
             "medium": {
                 "coins": [
-                    pygame.Rect(182, 430, 16, 16),
-                    pygame.Rect(332, 360, 16, 16),
-                    pygame.Rect(482, 290, 16, 16),
-                    pygame.Rect(632, 220, 16, 16),
-                    pygame.Rect(232, 140, 16, 16),
-                    pygame.Rect(832, 140, 16, 16),
-                    pygame.Rect(1482, 290, 16, 16),
-                    pygame.Rect(600, 500, 16, 16),
-                    pygame.Rect(700, 500, 16, 16),
-                    pygame.Rect(1200, 500, 16, 16),
-                    pygame.Rect(1300, 500, 16, 16),
-                    pygame.Rect(1400, 500, 16, 16),
-                    pygame.Rect(1900, 500, 16, 16),
-                    pygame.Rect(2000, 500, 16, 16),
-                    pygame.Rect(2100, 500, 16, 16),
+                    (182, 0.597),
+                    (332, 0.5),
+                    (482, 0.403),
+                    (632, 0.306),
+                    (232, 0.194),
+                    (832, 0.194),
+                    (1482, 0.403),
+                    (600, 0.694),
+                    (700, 0.694),
+                    (1200, 0.694),
+                    (1300, 0.694),
+                    (1400, 0.694),
+                    (1900, 0.694),
+                    (2000, 0.694),
+                    (2100, 0.694),
                 ],
                 "boosts": [
-                    pygame.Rect(1332, 220, 16, 16),
+                    (1332, 0.306),
                 ]
             }
         }
 
-    def get_items_and_boosts(self, difficulty):
+    def get_items_and_boosts(self, difficulty, screen_width=1280, screen_height=720):
         difficulty = difficulty.lower()
         data = self.item_data.get(difficulty, self.item_data["medium"])
-        return data["coins"].copy(), data["boosts"].copy()
+        coins = [pygame.Rect(x, int(screen_height * y), 16, 16) for x, y in data["coins"]]
+        boosts = [pygame.Rect(x, int(screen_height * y), 16, 16) for x, y in data["boosts"]]
+        return coins, boosts

--- a/src/maingame.py
+++ b/src/maingame.py
@@ -63,7 +63,7 @@ class MainGame:
 
         ground_rects = terrain_data["ground_rects"]
         platform_rects = terrain_data["platform_rects"]
-        item_rects, boost_rects = items.get_items_and_boosts(difficulty)
+        item_rects, boost_rects = items.get_items_and_boosts(difficulty, self.WIDTH, self.HEIGHT)
 
         background = pygame.image.load("assets/sprites/game_sprites/background.png").convert()
         background_width = background.get_width()
@@ -118,7 +118,7 @@ class MainGame:
                 terrain_data = terrain.get_map(difficulty)
                 ground_rects = terrain_data["ground_rects"]
                 platform_rects = terrain_data["platform_rects"]
-                item_rects, boost_rects = items.get_items_and_boosts(difficulty)
+                item_rects, boost_rects = items.get_items_and_boosts(difficulty, self.WIDTH, self.HEIGHT)
                 score = 0
 
             scroll_x = max(0, min(player.x - self.WIDTH // 2, background_width - self.WIDTH))


### PR DESCRIPTION
This pull request refactors item and boost handling in the game by introducing a new `Items` class to encapsulate their logic. The changes improve code organization and maintainability by moving item and boost data out of the `Terrain` class and into the new `Items` class.

### Refactoring for item and boost handling:
* Added import for the new `Items` class in `src/maingame.py` and instantiated it in the `play` method to manage item and boost data. (`[[1]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R9)`, `[[2]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R60-R66)`, `[[3]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R117-R121)`)
* Replaced direct access to `items` and `boosts` in the `Terrain` data with a call to `items.get_items_and_boosts(difficulty)` in the `play` method. (`[[1]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R60-R66)`, `[[2]](diffhunk://#diff-88d8f9657d9b720dea550ea94565e752a99f3e7dded39a3c1387f933676a0ea5R117-R121)`)

### Code cleanup in `Terrain`:
* Removed hardcoded `items` and `boosts` data from the `Terrain` class, as this responsibility has been moved to the `Items` class. (`[src/terrain.pyL32-L52](diffhunk://#diff-fd86f3d8b7d2a19acc00ef758873e04d1f5d42da59716823e49b6dd179de7a6eL32-L52)`)